### PR TITLE
merge new stats with previous file content

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ This plugin adds some new options to `nosetests`:
                       Output file name; default "stats.dat"
 --cprofile-stats-erase
                       Erase previously-collected profiling statistics before
-                      run
+                      run. Without this options, new profiling stats will be
+                      merged with prior content of the output file.
 ```

--- a/nose_cprofile/nose_cprofile.py
+++ b/nose_cprofile/nose_cprofile.py
@@ -1,6 +1,7 @@
 import cProfile
 import logging
 import os
+import pstats
 
 import nose
 from nose.plugins.base import Plugin
@@ -58,7 +59,12 @@ class cProfiler(Plugin):
 
         def run_and_profile(result, prof=self.prof, test=test):
             prof.runcall(test, result)
-            prof.dump_stats(self.pfile_name)
+            stats = pstats.Stats(prof)
+            if os.path.exists(self.pfile_name):
+                log.debug('accumulating current stats in existing file %s'
+                          % self.pfile_name)
+                stats.add(self.pfile_name)
+            stats.dump_stats(self.pfile_name)
         return run_and_profile
 
     def finalize(self, result):


### PR DESCRIPTION
Merging new stats with previous file content can be prevented by
providing ``cprofile-stats-erase`` command line argument.